### PR TITLE
Automatically wildcard searches

### DIFF
--- a/src/server/controllers/experiment.controller.js
+++ b/src/server/controllers/experiment.controller.js
@@ -298,6 +298,13 @@ const reindex = async (req, res) => {
 const choices = async (req, res) => {
   try {
     const attribute = req.params.attribute;
+    const query = req.query;
+
+    // add wildcards if not already set
+    if (query.q && !query.q.indexOf("*") > -1) {
+      query.q = `*${query.q}*`;
+    }
+
     const resp = await ElasticsearchHelper.aggregate(
       config,
       experimentSchema,
@@ -317,7 +324,12 @@ const choices = async (req, res) => {
  */
 const search = async (req, res) => {
   try {
-    const query = req.query;
+    const query = JSON.parse(JSON.stringify(req.query));
+
+    // add wildcards if not already set
+    if (query.q && !query.q.indexOf("*") > -1) {
+      query.q = `*${query.q}*`;
+    }
 
     // only allow the whitelist of filters if set
     const whitelist = ExperimentsHelper.getFiltersWhitelist();

--- a/src/server/tests/controllers/experiment.elasticsearch.test.js
+++ b/src/server/tests/controllers/experiment.elasticsearch.test.js
@@ -196,6 +196,29 @@ describe("## Experiment APIs", () => {
           done();
         });
     });
+    it("should apply partial match free text queries", done => {
+      request(app)
+        .get("/experiments/choices?q=emale")
+        .set("Authorization", `Bearer ${token}`)
+        .expect(httpStatus.OK)
+        .end((err, res) => {
+          expect(res.body.status).toEqual("success");
+
+          const data = res.body.data;
+          expect(data["metadata.patient.age"].min).toEqual(32);
+          expect(data["metadata.patient.age"].max).toEqual(32);
+          expect(data["metadata.patient.bmi"].min).toEqual(33.1);
+          expect(data["metadata.patient.bmi"].max).toEqual(33.1);
+          expect(data["metadata.sample.dateArrived"].min).toEqual(
+            "2017-11-05T00:00:00.000Z"
+          );
+          expect(data["metadata.sample.dateArrived"].max).toEqual(
+            "2017-11-05T00:00:00.000Z"
+          );
+
+          done();
+        });
+    });
     it("should be a protected route", done => {
       request(app)
         .get("/experiments/choices")
@@ -260,6 +283,21 @@ describe("## Experiment APIs", () => {
           expect(res.body.data.results.length).toEqual(1);
           expect(res.body.data).toHaveProperty("search");
           expect(res.body.data.search).toHaveProperty("q", "Female");
+          done();
+        });
+    });
+    it("should partial match free text search queries", done => {
+      request(app)
+        .get("/experiments/search?q=emale")
+        .set("Authorization", `Bearer ${token}`)
+        .expect(httpStatus.OK)
+        .end((err, res) => {
+          expect(res.body.status).toEqual("success");
+          expect(res.body.data).toHaveProperty("total", 1);
+          expect(res.body.data).toHaveProperty("results");
+          expect(res.body.data.results.length).toEqual(1);
+          expect(res.body.data).toHaveProperty("search");
+          expect(res.body.data.search).toHaveProperty("q", "emale");
           done();
         });
     });


### PR DESCRIPTION
Default search for "all" will use analyser for each field i.e. require a full match for keywords.  Adding wildcards will allow a partial match.